### PR TITLE
Give credit where credit is due.

### DIFF
--- a/app/src/main/java/com/series/aster/launcher/helper/AppHelper.kt
+++ b/app/src/main/java/com/series/aster/launcher/helper/AppHelper.kt
@@ -173,6 +173,7 @@ class AppHelper @Inject constructor() {
         Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     }
 
+    // https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Utils.kt#L367
     fun showStatusBar(window: Window) {
         //show statusBar
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -185,6 +186,7 @@ class AppHelper @Inject constructor() {
             }
     }
 
+    // https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Utils.kt#L378
     fun hideStatusBar(window: Window) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
             window.insetsController?.hide(WindowInsets.Type.statusBars())
@@ -208,7 +210,8 @@ class AppHelper @Inject constructor() {
         val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(view.windowToken, 0)
     }
-
+    
+    // https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Extensions.kt#L15
     fun View.hideKeyboard() {
         val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         imm.hideSoftInputFromWindow(this.windowToken, 0)


### PR DESCRIPTION
Hello, I have been looking through your code and have come across a few of my functions in your code base from mLauncher. [showStatusBar](https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Utils.kt#L367), [hideStatusBar](https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Utils.kt#L378) and [View.hideKeyboard](https://github.com/DroidWorksStudio/mLauncher/blob/34454baae46e0ca91d57545f6c8d29f6b3ec7f5e/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Extensions.kt#L15) which is not giving credit to. as you can see [resetDefaultLauncher](https://github.com/DroidWorksStudio/mLauncher/blob/main/app/src/main/java/com/github/droidworksstudio/mlauncher/helper/Utils.kt#L233) which I give stackoverflow credit for so id also like the credit of my functions to be added to your project. feel free to also use my `resetDefaultLauncher` function if you wish but also add credit for that too. 

Even the function names are the same. yes you changed them from using `activity: Activity` to `window: Window` directly but other then that they are word for word the same thing.

here is what i plan to change mine to soon if you also want to use it feel free as long as you give me credit for it.
```kotlin
fun resetDefaultLauncher(context: Context) {
    try {
        val packageManager = context.packageManager
        val componentName = ComponentName(context, FakeHomeActivity::class.java)

        packageManager.setComponentEnabledSetting(
            componentName,
            PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
            PackageManager.DONT_KILL_APP
        )

        val selector = Intent(Intent.ACTION_MAIN)
        selector.addCategory(Intent.CATEGORY_HOME)
        context.startActivity(selector)

        packageManager.setComponentEnabledSetting(
            componentName,
            PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
            PackageManager.DONT_KILL_APP
        )
    } catch (e: Exception) {
        e.printStackTrace()
        
        // Additional step to open the launcher settings if the first method fails
        try {
            val intent = Intent("android.settings.HOME_SETTINGS")
            context.startActivity(intent)
        } catch (e: ActivityNotFoundException) {
            // Fallback to general settings if specific launcher settings are not found
            try {
                val intent = Intent(android.provider.Settings.ACTION_SETTINGS)
                context.startActivity(intent)
            } catch (e: Exception) {
                e.printStackTrace()
            }
        }
    }
}
```

